### PR TITLE
VSEMFORM-251 added possibility to set options for "down"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@ SHELL := /bin/bash
 -include tools/*/include.mk
 
 DOCKER_OPTIONS := --progress=plain --env-file .env.deploy --env-file .env
-SERVICE ?= ""
+SERVICE ?=
+DOWN_OPTIONS ?=
 
 .PHONY: compose start
 
 start:
 	docker compose $(DOCKER_OPTIONS) pull --include-deps $(SERVICE)
-	docker compose $(DOCKER_OPTIONS) down $(SERVICE) || true
+	docker compose $(DOCKER_OPTIONS) down $(DOWN_OPTIONS) $(SERVICE) || true
 
 	source .env.deploy; if [[ -n "$${PROJECT_EXTERNAL_NETWORK:-}" ]]; then \
 		docker 2>/dev/null 1>&2 network create --driver bridge $$PROJECT_EXTERNAL_NETWORK || true; \

--- a/action.yml
+++ b/action.yml
@@ -87,4 +87,4 @@ runs:
             scp ${PROXY_COMMAND} ${strarr[0]} ${{ inputs.server }}:${{ inputs.server_deploy_dir }}/${strarr[1]} ; \
           done ; \
         fi
-        ssh ${PROXY_COMMAND} ${{ inputs.server }} "which make 2>/dev/null || apt-get install make; cd ${{ inputs.server_deploy_dir }}; make start SERVICE=${{ inputs.service }}" DOWN_OPTIONS=${{ inputs.down_options }}"
+        ssh ${PROXY_COMMAND} ${{ inputs.server }} "which make 2>/dev/null || apt-get install make; cd ${{ inputs.server_deploy_dir }}; make start SERVICE=${{ inputs.service }} DOWN_OPTIONS=${{ inputs.down_options }}"

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: "The name of the service to deploy."
     required: false
     default: ""
+  down_options:
+    description: "Options for `docker compose down` command"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -83,4 +87,4 @@ runs:
             scp ${PROXY_COMMAND} ${strarr[0]} ${{ inputs.server }}:${{ inputs.server_deploy_dir }}/${strarr[1]} ; \
           done ; \
         fi
-        ssh ${PROXY_COMMAND} ${{ inputs.server }} "which make 2>/dev/null || apt-get install make; cd ${{ inputs.server_deploy_dir }}; make start SERVICE=${{ inputs.service }}"
+        ssh ${PROXY_COMMAND} ${{ inputs.server }} "which make 2>/dev/null || apt-get install make; cd ${{ inputs.server_deploy_dir }}; make start SERVICE=${{ inputs.service }}" DOWN_OPTIONS=${{ inputs.down_options }}"


### PR DESCRIPTION
potřeboval jsem použít **docker compose down** s **-v** na projektu vsem-communicator, což imatic-lxc-deploy-action zatím neumožňuje, a proto navrhuji tuto možnost zadat parametr pro **down**.